### PR TITLE
Add space after the comma when inserting multiple inputs

### DIFF
--- a/ess-r-insert-obj.el
+++ b/ess-r-insert-obj.el
@@ -72,8 +72,8 @@
 
 From R data to Emacs list."
   :type `(choice ,@(mapcar (lambda (x)
-			                 `(const :tag ,(symbol-name x) ,x))
-			               ess-r-insert-obj-complete-backend-list)
+                             `(const :tag ,(symbol-name x) ,x))
+                           ess-r-insert-obj-complete-backend-list)
                  (symbol :tag "Other"))
   :group 'ess-r-insert-obj)
 
@@ -116,10 +116,10 @@ Argument STR R script to run.")
 Optional argument DATAFRAME name of data.frame-like object."
   (let ((cmd
          (concat
-           "jsonlite::toJSON("
-           (format "c(list(%1$s = names(%1$s)), lapply(%1$s, function(x) as.character(unique(x))))"
-                   (or dataframe ess-r-insert-obj-object))
-           ")\n")))
+          "jsonlite::toJSON("
+          (format "c(list(%1$s = names(%1$s)), lapply(%1$s, function(x) as.character(unique(x))))"
+                  (or dataframe ess-r-insert-obj-object))
+          ")\n")))
     (json-read-from-string (ess-string-command cmd))))
 
 
@@ -291,34 +291,34 @@ prompt for a data.frame-like object to search in."
          dt-insert)
 
     (when (or (equal current-prefix-arg '(16))
-            (null (save-excursion
-                    (save-restriction
-                      (setq dt-insert (ess-r-insert-obj--previous-complete-object 'dt-insert))))))
+              (null (save-excursion
+                      (save-restriction
+                        (setq dt-insert (ess-r-insert-obj--previous-complete-object 'dt-insert))))))
       ;; force refresh
       (let ((objs (ess-r-insert-obj-get-objects)))
-            (setq ess-r-insert-obj-object
-                  (funcall ess-r-insert-obj-read-string
-                           "data.frame: " objs
-                           nil t))
-            (when (and proc-name proc
-                       (not (process-get proc 'busy)))
-              (setq ess-r-insert-obj-candidate
-                    (ess-r-insert-obj-do-complete-data ess-r-insert-obj-current-complete-backend))))
+        (setq ess-r-insert-obj-object
+              (funcall ess-r-insert-obj-read-string
+                       "data.frame: " objs
+                       nil t))
+        (when (and proc-name proc
+                   (not (process-get proc 'busy)))
+          (setq ess-r-insert-obj-candidate
+                (ess-r-insert-obj-do-complete-data ess-r-insert-obj-current-complete-backend))))
       (setq dt-insert ess-r-insert-obj-object))
 
     (when dt-insert
-        (let* ((obj-list (append
-                          (if (assq (intern ess-r-insert-obj-object)
-                                    ess-r-insert-obj-candidate)
-                              (alist-get (intern ess-r-insert-obj-object)
-                                         ess-r-insert-obj-candidate)
-                            (alist-get (intern (replace-regexp-in-string
-                                                "`" "" ess-r-insert-obj-object))
-                                       ess-r-insert-obj-candidate))
-                          nil)))
-          (insert (propertize (mapconcat 'identity
-                               'dt-insert dt-insert))))))
+      (let* ((obj-list (append
+                        (if (assq (intern ess-r-insert-obj-object)
+                                  ess-r-insert-obj-candidate)
+                            (alist-get (intern ess-r-insert-obj-object)
+                                       ess-r-insert-obj-candidate)
+                          (alist-get (intern (replace-regexp-in-string
+                                              "`" "" ess-r-insert-obj-object))
+                                     ess-r-insert-obj-candidate))
+                        nil)))
+        (insert (propertize (mapconcat 'identity
                                        (delete-dups obj-list) ", ")
+                            'dt-insert dt-insert))))))
 
 ;;;###autoload
 (defun ess-r-insert-obj-value ()
@@ -344,8 +344,8 @@ prompt for a data.frame-like object to search in."
 
     (when (or (equal current-prefix-arg '(16))
               (null (save-excursion
-                     (save-restriction
-                       (setq dt-insert (ess-r-insert-obj--previous-complete-object 'dt-insert))))))
+                      (save-restriction
+                        (setq dt-insert (ess-r-insert-obj--previous-complete-object 'dt-insert))))))
       (let* ((objs (ess-r-insert-obj-get-objects)))
         (setq ess-r-insert-obj-object
               (funcall ess-r-insert-obj-read-string
@@ -377,28 +377,28 @@ prompt for a data.frame-like object to search in."
                      nil t)))
 
     (when (and dt-insert col-insert)
-          (let* ((possible-completions (ess-r-get-rcompletions))
-                 (token-string (or (car possible-completions) ""))
-                 (start (- (point) (length token-string)))
-                 (end (point))
-                 com)
-            (setq com
-                  (funcall ess-r-insert-obj-read-string
-                           "Value: "
-                           (delq nil (delete-dups (append
-                            (if (assq (intern col-insert)
-                                      ess-r-insert-obj-candidate)
-                                (alist-get (intern col-insert)
-                                           ess-r-insert-obj-candidate)
-                              (alist-get (intern (replace-regexp-in-string
-                                                  "`" "" col-insert))
-                                         ess-r-insert-obj-candidate))
-                            nil)))
-                           nil t token-string))
-            (delete-region start end)
-            (insert (propertize (format "\"%s\"" com)
-                                'dt-insert dt-insert
-                                'col-insert col-insert))))))
+      (let* ((possible-completions (ess-r-get-rcompletions))
+             (token-string (or (car possible-completions) ""))
+             (start (- (point) (length token-string)))
+             (end (point))
+             com)
+        (setq com
+              (funcall ess-r-insert-obj-read-string
+                       "Value: "
+                       (delq nil (delete-dups (append
+                                               (if (assq (intern col-insert)
+                                                         ess-r-insert-obj-candidate)
+                                                   (alist-get (intern col-insert)
+                                                              ess-r-insert-obj-candidate)
+                                                 (alist-get (intern (replace-regexp-in-string
+                                                                     "`" "" col-insert))
+                                                            ess-r-insert-obj-candidate))
+                                               nil)))
+                       nil t token-string))
+        (delete-region start end)
+        (insert (propertize (format "\"%s\"" com)
+                            'dt-insert dt-insert
+                            'col-insert col-insert))))))
 
 ;;;###autoload
 (defun ess-r-insert-obj-value-all ()
@@ -424,8 +424,8 @@ prompt for a data.frame-like object to search in."
 
     (when (or (equal current-prefix-arg '(16))
               (null (save-excursion
-                     (save-restriction
-                       (setq dt-insert (ess-r-insert-obj--previous-complete-object 'dt-insert))))))
+                      (save-restriction
+                        (setq dt-insert (ess-r-insert-obj--previous-complete-object 'dt-insert))))))
       (let* ((objs (ess-r-insert-obj-get-objects)))
         (setq ess-r-insert-obj-object
               (funcall ess-r-insert-obj-read-string

--- a/ess-r-insert-obj.el
+++ b/ess-r-insert-obj.el
@@ -250,14 +250,14 @@ prompt for a data.frame-like object to search in."
                                    (format "Column (%s), C-j to finish"
                                            (mapconcat 'identity
                                                       (setq objs2 (nreverse objs2))
-                                                      ","))
+                                                      ", "))
                                    objs))
                 (unless (equal obj "")
                   (setq objs (delete obj objs))
                   (cl-pushnew obj obj-list)
                   (cl-pushnew obj objs2)))
               (unless (null obj-list)
-                (insert (propertize (mapconcat 'identity (delete-dups (nreverse obj-list)) ",")
+                (insert (propertize (mapconcat 'identity (delete-dups (nreverse obj-list)) ", ")
                                     'dt-insert dt-insert))))
           (let* ((possible-completions (ess-r-get-rcompletions))
                  (token-string (or (car possible-completions) ""))
@@ -317,8 +317,8 @@ prompt for a data.frame-like object to search in."
                                        ess-r-insert-obj-candidate))
                           nil)))
           (insert (propertize (mapconcat 'identity
-                                          (delete-dups obj-list) ",")
                                'dt-insert dt-insert))))))
+                                       (delete-dups obj-list) ", ")
 
 ;;;###autoload
 (defun ess-r-insert-obj-value ()
@@ -467,7 +467,7 @@ prompt for a data.frame-like object to search in."
                                      ess-r-insert-obj-candidate))
                         nil)))
         (insert (propertize (mapconcat 'identity
-                                       (delete-dups obj-list) ",")
+                                       (delete-dups obj-list) ", ")
                             'dt-insert dt-insert
                             'col-insert col-insert))))))
 


### PR DESCRIPTION
This change acts when the user chooses multiple inputs from
the completing-read backend. Then, the inserted text is now
separated by whitespace after the comma. For example, selecting
two columns from `mtcars` data frame returns:

```r
select(mtcars, mpg, cyl)
```